### PR TITLE
Always call the callback even when mining is disabled

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -493,6 +493,8 @@ Node.prototype.getStats = function(forced)
 			{
 				if (web3.eth.mining) {
 					web3.eth.getHashrate(callback);
+				} else {
+				    callback(null, 0);
 				}
 			},
 			gasPrice: function (callback)


### PR DESCRIPTION
When retrieving the hash rate within the async block, we need to make sure the callback is always called - even if we skip calling the actual JSON-RPC method because mining disabled.  Otherwise the overall async never completes because it continues waiting for this remaining function.