### PR TITLE
Fixes to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,14 +36,14 @@ FROM debian
 
 RUN apt-get update &&\
     apt-get install -y curl git-core &&\
-    curl -sL https://deb.nodesource.com/setup | bash - &&\
+    curl -sL https://deb.nodesource.com/setup_14.x | bash - &&\
     apt-get update &&\
     apt-get install -y nodejs
 
 RUN apt-get update &&\
     apt-get install -y build-essential
 
-RUN adduser ethnetintel
+RUN useradd -m ethnetintel
 
 RUN cd /home/ethnetintel &&\
     git clone https://github.com/cubedro/eth-net-intelligence-api &&\
@@ -51,11 +51,10 @@ RUN cd /home/ethnetintel &&\
     npm install &&\
     npm install -g pm2
 
-RUN echo '#!/bin/bash\nset -e\n\ncd /home/ethnetintel/eth-net-intelligence-api\n/usr/bin/pm2 start ./app.json\ntail -f \
-    /home/ethnetintel/.pm2/logs/node-app-out-0.log' > /home/ethnetintel/startscript.sh
-
-RUN chmod +x /home/ethnetintel/startscript.sh &&\
-    chown -R ethnetintel. /home/ethnetintel
+RUN chown -R ethnetintel. /home/ethnetintel
 
 USER ethnetintel
-ENTRYPOINT ["/home/ethnetintel/startscript.sh"]
+
+WORKDIR /home/ethnetintel/eth-net-intelligence-api
+
+CMD [ "pm2-runtime", "app.json" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,29 +32,20 @@
 ## If you now want to deploy a new client version, just redo the second step.
 
 
-FROM debian
+FROM node:14-alpine
 
-RUN apt-get update &&\
-    apt-get install -y curl git-core &&\
-    curl -sL https://deb.nodesource.com/setup_14.x | bash - &&\
-    apt-get update &&\
-    apt-get install -y nodejs
-
-RUN apt-get update &&\
-    apt-get install -y build-essential
-
-RUN useradd -m ethnetintel
-
-RUN cd /home/ethnetintel &&\
-    git clone https://github.com/cubedro/eth-net-intelligence-api &&\
-    cd eth-net-intelligence-api &&\
-    npm install &&\
-    npm install -g pm2
-
-RUN chown -R ethnetintel. /home/ethnetintel
-
-USER ethnetintel
+RUN apk update && apk add git ca-certificates
+RUN adduser -S ethnetintel
 
 WORKDIR /home/ethnetintel/eth-net-intelligence-api
+
+ADD package.json .
+RUN npm install && npm install -g pm2
+
+ADD . .
+
+RUN chown -R ethnetintel. .
+
+USER ethnetintel
 
 CMD [ "pm2-runtime", "app.json" ]


### PR DESCRIPTION
* Use Alpine over Debian

* Install NodeJS 14 - The current recommended version. The old script is depreciated.

* Run `useradd` instead of `adduser` - Removes some error messages.

* Switch from `pm2 start` script to `pm2-runtime` command. - This is the recommended way to run pm2 in docker. It also stops us from crashing when the app name changes and the log file is missing,